### PR TITLE
Improve performance of segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ print([word for word in search])
 use instant_segment::{Search, Segmenter};
 use std::collections::HashMap;
 
-let segmenter = Segmenter::from_maps(unigrams, bigrams);
+let segmenter = Segmenter::new(unigrams, bigrams);
 let mut search = Search::default();
 let words = segmenter
     .segment("instantdomainsearch", &mut search)

--- a/instant-segment-py/Cargo.toml
+++ b/instant-segment-py/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bincode = "1.3.2"
-instant-segment = { version = "0.10", path = "../instant-segment", features = ["with-serde"] }
+instant-segment = { version = "0.11", path = "../instant-segment", features = ["with-serde"] }
 pyo3 = { version = "0.20", features = ["extension-module"] }
 smartstring = "1"
 

--- a/instant-segment-py/Cargo.toml
+++ b/instant-segment-py/Cargo.toml
@@ -16,7 +16,6 @@ name = "instant_segment"
 crate-type = ["cdylib"]
 
 [dependencies]
-ahash = "0.8"
 bincode = "1.3.2"
 instant-segment = { version = "0.10", path = "../instant-segment", features = ["with-serde"] }
 pyo3 = { version = "0.20", features = ["extension-module"] }

--- a/instant-segment-py/Cargo.toml
+++ b/instant-segment-py/Cargo.toml
@@ -2,6 +2,7 @@
 name = "instant-segment-py"
 version = "0.1.5"
 edition = "2018"
+rust-version = "1.65"
 license = "Apache-2.0"
 workspace = ".."
 description = "Fast English word segmentation"

--- a/instant-segment-py/src/lib.rs
+++ b/instant-segment-py/src/lib.rs
@@ -39,7 +39,7 @@ impl Segmenter {
                 let val = item.get_item(1)?.extract::<f64>()?;
                 Ok((SmartString::from(key), val))
             })
-            .collect::<Result<HashMap<_, _>, PyErr>>()?;
+            .collect::<Result<Vec<_>, PyErr>>()?;
 
         let bigrams = bigrams
             .map(|item| {
@@ -52,10 +52,10 @@ impl Segmenter {
                 let val = item.get_item(1)?.extract::<f64>()?;
                 Ok(((SmartString::from(first), SmartString::from(second)), val))
             })
-            .collect::<Result<HashMap<_, _>, PyErr>>()?;
+            .collect::<Result<Vec<_>, PyErr>>()?;
 
         Ok(Self {
-            inner: instant_segment::Segmenter::from_maps(unigrams, bigrams),
+            inner: instant_segment::Segmenter::new(unigrams, bigrams),
         })
     }
 
@@ -148,5 +148,3 @@ impl Search {
         Some(word)
     }
 }
-
-type HashMap<K, V> = std::collections::HashMap<K, V, ahash::RandomState>;

--- a/instant-segment/Cargo.toml
+++ b/instant-segment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "instant-segment"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2018"
 rust-version = "1.65"
 license = "Apache-2.0"

--- a/instant-segment/Cargo.toml
+++ b/instant-segment/Cargo.toml
@@ -13,10 +13,10 @@ readme = "../README.md"
 [features]
 __test_data = ["test-cases"]
 test-cases = []
-with-serde = ["serde", "ahash/serde", "smartstring/serde"]
+with-serde = ["serde", "smartstring/serde"]
 
 [dependencies]
-ahash = "0.8"
+rustc-hash = "1.1.0"
 smartstring = "1"
 serde = { version = "1.0.123", features = ["derive"], optional = true }
 

--- a/instant-segment/Cargo.toml
+++ b/instant-segment/Cargo.toml
@@ -2,6 +2,7 @@
 name = "instant-segment"
 version = "0.10.1"
 edition = "2018"
+rust-version = "1.65"
 license = "Apache-2.0"
 description = "Fast English word segmentation"
 homepage = "https://github.com/InstantDomain/instant-segment"

--- a/instant-segment/benches/bench.rs
+++ b/instant-segment/benches/bench.rs
@@ -5,7 +5,7 @@ use bencher::{benchmark_group, benchmark_main, Bencher};
 use instant_segment::test_data::{crate_data_dir, segmenter};
 use instant_segment::Search;
 
-benchmark_group!(benches, short);
+benchmark_group!(benches, short, long);
 benchmark_main!(benches);
 
 fn short(bench: &mut Bencher) {
@@ -13,5 +13,16 @@ fn short(bench: &mut Bencher) {
     let mut search = Search::default();
     bench.iter(|| {
         let _ = segmenter.segment("thisisatest", &mut search);
+    });
+}
+
+fn long(bench: &mut Bencher) {
+    let segmenter = segmenter(crate_data_dir());
+    let mut search = Search::default();
+    bench.iter(|| {
+        let _ = segmenter.segment(
+            "itwasabrightcolddayinaprilandtheclockswerestrikingthirteen",
+            &mut search,
+        );
     });
 }

--- a/instant-segment/examples/contrived.rs
+++ b/instant-segment/examples/contrived.rs
@@ -2,7 +2,7 @@ use instant_segment::{Search, Segmenter};
 use std::collections::HashMap;
 
 fn main() {
-    let mut unigrams = HashMap::default();
+    let mut unigrams = HashMap::new();
 
     unigrams.insert("choose".into(), 80_000.0);
     unigrams.insert("chooses".into(), 7_000.0);
@@ -10,12 +10,12 @@ fn main() {
     unigrams.insert("spain".into(), 20_000.0);
     unigrams.insert("pain".into(), 90_000.0);
 
-    let mut bigrams = HashMap::default();
+    let mut bigrams = HashMap::new();
 
     bigrams.insert(("choose".into(), "spain".into()), 7.0);
     bigrams.insert(("chooses".into(), "pain".into()), 0.0);
 
-    let segmenter = Segmenter::from_maps(unigrams, bigrams);
+    let segmenter = Segmenter::new(unigrams, bigrams);
     let mut search = Search::default();
 
     let words = segmenter.segment("choosespain", &mut search).unwrap();

--- a/instant-segment/examples/merge.rs
+++ b/instant-segment/examples/merge.rs
@@ -4,12 +4,12 @@
 //! data files from publicly available sources. See the README in `/data`.
 
 use std::cmp::Reverse;
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::Write;
 use std::io::{BufRead, BufReader, BufWriter};
 use std::str::FromStr;
 
-use ahash::{AHashMap as HashMap, AHashSet as HashSet};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use smartstring::alias::String as SmartString;
 

--- a/instant-segment/src/lib.rs
+++ b/instant-segment/src/lib.rs
@@ -256,7 +256,7 @@ impl std::fmt::Display for InvalidCharacter {
     }
 }
 
-type HashMap<K, V> = std::collections::HashMap<K, V, ahash::RandomState>;
+type HashMap<K, V> = rustc_hash::FxHashMap<K, V>;
 
 const DEFAULT_LIMIT: usize = 24;
 

--- a/instant-segment/src/test_data.rs
+++ b/instant-segment/src/test_data.rs
@@ -56,7 +56,7 @@ pub fn segmenter(dir: PathBuf) -> Segmenter {
         ln.clear();
     }
 
-    Segmenter::from_maps(unigrams, bigrams)
+    Segmenter::new(unigrams, bigrams)
 }
 
 pub fn crate_data_dir() -> PathBuf {


### PR DESCRIPTION
This PR improves the speed of segmentation by pre-computing more values, using a different data structure for storing unigram and bigram data, and switching to a different hash function. In total, we achieve a 5-6x speed-up.

Here is what's happening:

1. [The first commit](https://github.com/instant-labs/instant-segment/commit/1aeee2129fff601b880f9130900cff7b9f52366d) just adds a second benchmark with a longer example. This is the performance we're starting with (on my machine):
```
test long  ... bench:     104,057 ns/iter (+/- 11,640)
test short ... bench:       4,902 ns/iter (+/- 439)
```

2. Then, in [Pre-compute unigram and bigram scores](https://github.com/instant-labs/instant-segment/commit/ea22d6cb654e159c52ac3681ac39170cd05b9312) we exploit the fact that `log(a * b) == log(a) + log(b)` and `log(a / b) == log(a) - log(b)` and apply this to the `score()` method. Once we've done that we see that we can pre-compute pretty much everything there by not storing the unigram and bigram counts in `Segmenter` but instead already the logarithms of the relative frequencies.
Result:
```
test long  ... bench:      86,257 ns/iter (+/- 8,231)
test short ... bench:       4,146 ns/iter (+/- 285)
```

3. [Use nested HashMap for storing both unigram and bigram scores](https://github.com/instant-labs/instant-segment/commit/dfee69080afcd8c22534b3c4fa080009e15feba9) is based on the observation that when we look up unigrams and bigrams in `score()` we have to calculate the hash value of `word` twice, and in cases where we do not have any unigram or bigram data for that particular word pair (the most common case) we actually unnecessarily compute hash values of 3 words (instead of just 1). By changing the data structure to a `HashMap<String, (f64, HashMap<String, f64>>` that maps a word to its unigram score & a nested HashMap in which the bigram score can be looked up using the previous word, we can reduce the amount of hashing needed quite a bit.
This will make construction of `Segmenter` more expensive, but since the intended usage pattern of this crate is to construct the `Segmenter` once and reuse it, this should be a worthwhile trade-off.
Result:
```
test long  ... bench:      19,651 ns/iter (+/- 2,097)
test short ... bench:       1,480 ns/iter (+/- 229)
```

5. Finally, we [Switch to rustc_hash instead of ahash](https://github.com/instant-labs/instant-segment/commit/6ed11a3562216339e835764c433f33b42ae9a2e1) as that performs better on small inputs, and, since we changed our data structure above, is now faster than `ahash`. I also tried `fnv` but it was slower than `rustc_hash` (but faster than `ahash`).
Final result:
```
test long  ... bench:      16,843 ns/iter (+/- 1,262)
test short ... bench:       1,081 ns/iter (+/- 223)
```

Note that 3. above is a breaking change, so will require a version-bump in the crate.
